### PR TITLE
[RES-4518] Fix Orillusion z-order sort util when using a reversed depth buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "v0.8.3-resolve.annotations.2",
+    "version": "v0.8.3-resolve.annotations.3",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/samples/render/Sample_TextureSampler.ts
+++ b/samples/render/Sample_TextureSampler.ts
@@ -79,7 +79,7 @@ class Sample_TextureSample {
             filter[GPUFilterMode.linear] = GPUFilterMode.linear;
 
             // enum GPUCompareFunction
-            let depthCompare = Object.fromEntries(Object.values(getGPUCompareFunction()).map(v => [v, v]));
+            let { ...depthCompare } = getGPUCompareFunction();
 
             // GUI
             GUIHelp.addFolder("Texture Sampler");

--- a/src/gfx/renderJob/collect/EntityCollect.ts
+++ b/src/gfx/renderJob/collect/EntityCollect.ts
@@ -278,9 +278,11 @@ export class EntityCollect {
                 //resume unchange status
                 renderNode.isRenderOrderChange = false;
             }
-            renderList.sort((a: RenderNode, b: RenderNode) => {
-                return a['__renderOrder'] > b['__renderOrder'] ? 1 : -1;
-            });
+
+            const sortFn: (a: RenderNode, b: RenderNode) => number = Engine3D.setting.render.useReversedDepth
+                ? (a, b) => (a['__renderOrder'] - b['__renderOrder'] > 0 ? -1 : 1)
+                : (a, b) => (a['__renderOrder'] - b['__renderOrder'] > 0 ? 1 : -1);
+            renderList.sort(sortFn);
         }
         return this;
     }

--- a/src/gfx/renderJob/collect/EntityCollect.ts
+++ b/src/gfx/renderJob/collect/EntityCollect.ts
@@ -280,8 +280,8 @@ export class EntityCollect {
             }
 
             const sortFn: (a: RenderNode, b: RenderNode) => number = Engine3D.setting.render.useReversedDepth
-                ? (a, b) => (a['__renderOrder'] - b['__renderOrder'] > 0 ? -1 : 1)
-                : (a, b) => (a['__renderOrder'] - b['__renderOrder'] > 0 ? 1 : -1);
+                ? (a, b) => b['__renderOrder'] - a['__renderOrder']
+                : (a, b) => a['__renderOrder'] - b['__renderOrder'];
             renderList.sort(sortFn);
         }
         return this;

--- a/src/util/ZSorterUtil.ts
+++ b/src/util/ZSorterUtil.ts
@@ -1,4 +1,5 @@
-﻿import { Camera3D } from '../core/Camera3D';
+﻿import { Engine3D } from '..';
+import { Camera3D } from '../core/Camera3D';
 import { Object3D } from '../core/entities/Object3D';
 import { Vector3 } from '../math/Vector3';
 
@@ -46,9 +47,11 @@ export class ZSorterUtil {
             this._zSortList.push(zSortItemObject3D);
         }
 
-        this._zSortList.sort((a, b) => {
-            return a.z - b.z > 0 ? 1 : -1;
-        });
+        const sortFn: (a: { z: number }, b: { z: number }) => number = Engine3D.setting.render.useReversedDepth
+            ? (a, b) => (a.z - b.z > 0 ? -1 : 1)
+            : (a, b) => (a.z - b.z > 0 ? 1 : -1);
+
+        this._zSortList.sort(sortFn);
 
         result ||= [];
         for (let item of this._zSortList) {
@@ -58,6 +61,14 @@ export class ZSorterUtil {
         return result;
     }
 
+    /**
+     * Return the z-buffer value of the object3D in the camera's view coordinates. Note that
+     * the returned value will NOT correct for the `useReversedDepth` render setting, i.e. the
+     * order will flip if you are using reversed depth buffers; this allows you to take
+     * advantage of the improved z-fighting properties of reversed depth buffers for distant
+     * objects, but requires flipping the order of your comparison functions when using
+     * reversed depth.
+     */
     public worldToCameraDepth(obj3d: Object3D, camera?: Camera3D): number {
         camera ||= obj3d.transform.view3D.camera;
         let z: number = 0;

--- a/src/util/ZSorterUtil.ts
+++ b/src/util/ZSorterUtil.ts
@@ -48,8 +48,8 @@ export class ZSorterUtil {
         }
 
         const sortFn: (a: { z: number }, b: { z: number }) => number = Engine3D.setting.render.useReversedDepth
-            ? (a, b) => (a.z - b.z > 0 ? -1 : 1)
-            : (a, b) => (a.z - b.z > 0 ? 1 : -1);
+            ? (a, b) => b.z - a.z
+            : (a, b) => a.z - b.z;
 
         this._zSortList.sort(sortFn);
 


### PR DESCRIPTION
## Description

We added reversed depth buffer support to Orillusion, which replaces depth with 1 - depth to reduce z-fighting (since this is used in Wellington and we need to share depth buffers). However, we didn't update the z-sorter util used for things like enforcing transparency rendering order to account for this switch in ordering. Add support to worldToCameraDepth for reversed z-buffers to fix this.

## Issue

[RES-4518](https://linear.app/resolve/issue/RES-4518)