### PR TITLE
[RES-4923] allow specifying device limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-add-ci",
+    "version": "0.8.5-dev.9-add-requiredDeviceLimits",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/src/gfx/graphics/webGpu/CanvasConfig.ts
+++ b/src/gfx/graphics/webGpu/CanvasConfig.ts
@@ -32,4 +32,8 @@ export type CanvasConfig = {
      * additional required features for GPU device
      */
     requiredDeviceFeatures?: GPUFeatureName[];
+    /**
+     * required limits for GPU device
+     */
+    requiredDeviceLimits?: GPUDeviceDescriptor['requiredLimits'];
 };

--- a/src/gfx/graphics/webGpu/Context3D.ts
+++ b/src/gfx/graphics/webGpu/Context3D.ts
@@ -97,7 +97,8 @@ export class Context3D extends CEventDispatcher {
             ],
             requiredLimits: {
                 minUniformBufferOffsetAlignment: 256,
-                maxStorageBufferBindingSize: this.adapter.limits.maxStorageBufferBindingSize
+                maxStorageBufferBindingSize: this.adapter.limits.maxStorageBufferBindingSize,
+                ...(canvasConfig?.requiredDeviceLimits || {})
             }
         });
 


### PR DESCRIPTION
This can be used to e.g. set `{ maxTextureDimension2D: 16384 }` (assuming `adapter.limits.maxTextureDimension2D >== 16384`)