### PR TITLE
Add render target clear and format options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-add-requiredDeviceLimits",
+    "version": "0.8.5-dev.9-add-render-target-clear-and-format-options",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/src/Engine3D.ts
+++ b/src/Engine3D.ts
@@ -23,6 +23,7 @@ import { Matrix4 } from './math/Matrix4';
 import { FXAAPost } from './gfx/renderJob/post/FXAAPost';
 import { PostProcessingComponent } from './components/post/PostProcessingComponent';
 import { GBufferFrame } from './gfx/renderJob/frame/GBufferFrame';
+import { GPUTextureFormat } from './gfx/graphics/webGpu/WebGPUConst';
 
 /** 
  * Orillusion 3D Engine
@@ -139,6 +140,9 @@ export class Engine3D {
             useReversedDepth: false,
             useCompressGBuffer: false,
             gi: false,
+            clearRenderTarget: true,
+            defaultRenderTargetColorFormat: GPUTextureFormat.rgba16float,
+            defaultRenderTargetDepthFormat: GPUTextureFormat.depth32float,
             postProcessing: {
                 bloom: {
                     downSampleStep: 3,

--- a/src/gfx/renderJob/frame/GBufferFrame.ts
+++ b/src/gfx/renderJob/frame/GBufferFrame.ts
@@ -1,4 +1,5 @@
 
+import { Engine3D } from "../../../Engine3D";
 import { RenderTexture } from "../../../textures/RenderTexture";
 import { webGPUContext } from "../../graphics/webGpu/Context3D";
 import { GPUTextureFormat } from "../../graphics/webGpu/WebGPUConst";
@@ -31,15 +32,26 @@ export class GBufferFrame extends RTFrame {
     ) {
         let attachments = this.renderTargets;
         let reDescriptors = this.rtDescriptors;
+        const clear: boolean | undefined = key === GBufferFrame.colorPass_GBuffer
+            ? Engine3D.setting.render.clearRenderTarget
+            : undefined
+            ;
+        const loadOp = clear ? 'clear' : 'load';
+        this.depthLoadOp = loadOp;
+
         if (outColor) {
             let colorDec = new RTDescriptor();
-            colorDec.loadOp = 'clear';
+            colorDec.loadOp = loadOp;
             this._colorBufferTex = RTResourceMap.createRTTexture(
                 key + RTResourceConfig.colorBufferTex_NAME,
                 rtWidth,
                 rtHeight,
-                GPUTextureFormat.rgba16float,
-                true
+                key === GBufferFrame.colorPass_GBuffer
+                    ? Engine3D.setting.render.defaultRenderTargetColorFormat
+                    : GPUTextureFormat.rgba16float,
+                true,
+                0,
+                clear,
             );
             attachments.push(this._colorBufferTex);
             reDescriptors.push(colorDec);
@@ -53,7 +65,7 @@ export class GBufferFrame extends RTFrame {
             undefined,
             1,
             0,
-            true,
+            clear,
             true
         );
         attachments.push(this._compressGBufferTex);
@@ -61,7 +73,7 @@ export class GBufferFrame extends RTFrame {
         if (depthTexture) {
             this.depthTexture = depthTexture;
         } else {
-            this.depthTexture = new RenderTexture(rtWidth, rtHeight, GPUTextureFormat.depth32float, false, undefined, 1, 0, true, true);
+            this.depthTexture = new RenderTexture(rtWidth, rtHeight, Engine3D.setting.render.defaultRenderTargetDepthFormat, false, undefined, 1, 0, clear, true);
             this.depthTexture.name = key + `_depthTexture`;
         }
 

--- a/src/gfx/renderJob/frame/RTResourceMap.ts
+++ b/src/gfx/renderJob/frame/RTResourceMap.ts
@@ -21,12 +21,9 @@ export class RTResourceMap {
     public static createRTTexture(name: string, rtWidth: number, rtHeight: number, format: GPUTextureFormat, useMipmap: boolean = false, sampleCount: number = 0, clear?: boolean) {
         let rt: RenderTexture = this.rtTextureMap.get(name);
         if (!rt) {
-            clear = clear !== undefined
-                ? clear
-                : name == RTResourceConfig.colorBufferTex_NAME
-                ? false
-                : true
-                ;
+            if (clear === undefined) {
+                clear = name !== RTResourceConfig.colorBufferTex_NAME;
+            }
             rt = new RenderTexture(rtWidth, rtHeight, format, useMipmap, undefined, 1, sampleCount, clear);
             rt.name = name;
             RTResourceMap.rtTextureMap.set(name, rt);

--- a/src/gfx/renderJob/frame/RTResourceMap.ts
+++ b/src/gfx/renderJob/frame/RTResourceMap.ts
@@ -18,14 +18,16 @@ export class RTResourceMap {
         this.rtViewQuad = new Map<string, ViewQuad>();
     }
 
-    public static createRTTexture(name: string, rtWidth: number, rtHeight: number, format: GPUTextureFormat, useMipmap: boolean = false, sampleCount: number = 0) {
+    public static createRTTexture(name: string, rtWidth: number, rtHeight: number, format: GPUTextureFormat, useMipmap: boolean = false, sampleCount: number = 0, clear?: boolean) {
         let rt: RenderTexture = this.rtTextureMap.get(name);
         if (!rt) {
-            if (name == RTResourceConfig.colorBufferTex_NAME) {
-                rt = new RenderTexture(rtWidth, rtHeight, format, useMipmap, undefined, 1, sampleCount, false);
-            } else {
-                rt = new RenderTexture(rtWidth, rtHeight, format, useMipmap, undefined, 1, sampleCount, true);
-            }
+            clear = clear !== undefined
+                ? clear
+                : name == RTResourceConfig.colorBufferTex_NAME
+                ? false
+                : true
+                ;
+            rt = new RenderTexture(rtWidth, rtHeight, format, useMipmap, undefined, 1, sampleCount, clear);
             rt.name = name;
             RTResourceMap.rtTextureMap.set(name, rt);
         }

--- a/src/gfx/renderJob/passRenderer/RenderContext.ts
+++ b/src/gfx/renderJob/passRenderer/RenderContext.ts
@@ -1,4 +1,5 @@
 import { ProfilerUtil } from "../../..";
+import { Engine3D } from '../../../Engine3D';
 import { WebGPUDescriptorCreator } from "../../graphics/webGpu/descriptor/WebGPUDescriptorCreator";
 import { GPUContext } from "../GPUContext";
 import { RTFrame } from "../frame/RTFrame";
@@ -47,7 +48,8 @@ export class RenderContext {
     }
 
     public beginOpaqueRenderPass() {
-        this.beginContinueRendererPassState('clear', 'clear');
+        const loadOp = Engine3D.setting.render.clearRenderTarget ? 'clear' : 'load';
+        this.beginContinueRendererPassState(loadOp, loadOp);
         this.begineNewCommand();
         this.beginNewEncoder();
     }

--- a/src/setting/RenderSetting.ts
+++ b/src/setting/RenderSetting.ts
@@ -29,6 +29,9 @@ export type RenderSetting = {
     useReversedDepth: boolean;
     useCompressGBuffer: boolean;
     gi: boolean;
+    clearRenderTarget: boolean;
+    defaultRenderTargetColorFormat: GPUTextureFormat;
+    defaultRenderTargetDepthFormat: GPUTextureFormat;
     /**
      * post effect
      */


### PR DESCRIPTION
Provide 3 new `RenderSetting` options that make it easier to re-use the Orillusion render target textures in separate rendering systems:
- `clearRenderTarget`: Whether the render target should be cleared at the start of an opaque render pass
- `defaultRenderTargetColorFormat`: `GPUTextureFormat` to use for the render target main color attachment.
- `defaultRenderTargetDepthFormat`: `GPUTextureFormat` to use for the render target depth buffer.

Together, these allow us to rely on Orillusion for all texture management, simplifying the Lightning Viewer texture management/lifecycle code.