### PR TITLE
fix zero size textures on hidden canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-add-render-target-clear-and-format-options",
+    "version": "0.8.5-dev.9-fix-zero-size-textures-on-hidden-canvas",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/src/gfx/graphics/webGpu/Context3D.ts
+++ b/src/gfx/graphics/webGpu/Context3D.ts
@@ -118,6 +118,9 @@ export class Context3D extends CEventDispatcher {
             colorSpace: `srgb`
         });
 
+        this.presentationSize[0] = this.canvas.width;
+        this.presentationSize[1] = this.canvas.height;
+
         this._resizeEvent = new CResizeEvent(CResizeEvent.RESIZE, { width: this.windowWidth, height: this.windowHeight })
         const resizeObserver = new ResizeObserver(() => {
             this.debouncedUpdateSize();
@@ -144,6 +147,10 @@ export class Context3D extends CEventDispatcher {
     }
 
     public updateSize() {
+        if (!this.canvas.clientWidth || !this.canvas.clientHeight) {
+            return;
+        }
+
         this._pixelRatio = this.canvasConfig?.devicePixelRatio || window.devicePixelRatio || 1;
         this._pixelRatio = Math.min(this._pixelRatio, 2.0);
         let w = Math.floor(this.canvas.clientWidth * this._pixelRatio);


### PR DESCRIPTION
initialize presentation size to canvas size so that user-provided
canvases with non-zero heights/widths will have textures allocated
correctly even if their clientWidth or clientHeight are zero (e.g. due
to the tab being minimized or the canvas not being displayed).