### PR TITLE
correct Vector3.copyFrom docstring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-fix-zero-size-textures-on-hidden-canvas",
+    "version": "0.8.5-dev.9-fix-Vector3.copyFrom-docstring",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/src/math/Vector3.ts
+++ b/src/math/Vector3.ts
@@ -589,8 +589,8 @@ export class Vector3 {
     }
 
     /**
-     * The components of the source vector are set to the current vector
-     * @param src Original vector
+     * Copies the data from a vector into this instance.
+     * @param src The vector to copy from.
      * @returns 
      */
     public copyFrom(src: Vector3): Vector3 {


### PR DESCRIPTION
Previously it made it sound like the copying was being applied to the
vector passed as an argument rather than `this`. New docstring matches
the phrasing on `Quaternion.copyFrom` docstring and makes it clearer
that `this` is the target.