### PR TITLE
[RES-5028] Fix getMappedRange crash on iPadOS 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-fix-zero-size-textures-on-hidden-canvas",
+    "version": "0.8.5-dev.9-use-GPUQueue.writeBuffer-to-fix-getMappedRange-error-on-iPadOS",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
@@ -427,6 +427,24 @@ export class GPUBufferBase {
         let bytesLen = len;
         let device = webGPUContext.device;
         if (mapAsyncArray.length > 0) {
+            // iPadOS/iOS 26 Safari-specific handling; those devices will
+            // occasionally crash using the `getMappedRange` call.
+            // `device.queue.writeBuffer` is not universally available, so use
+            // manual buffer copying with `mapAsync` as a fallback.
+            if (typeof device.queue.writeBuffer !== 'undefined') {
+                if (len > mapAsyncArray.length) {
+                    throw new Error(`GPUBufferBase mapAsyncWrite length error. Tried to write ${len} float32s but array is only ${mapAsyncArray.length} float32s long.`);
+                }
+                webGPUContext.device.queue.writeBuffer(
+                    this.buffer,
+                    0,
+                    mapAsyncArray.buffer,
+                    mapAsyncArray.byteOffset,
+                    len * 4,
+                )
+                return;
+            }
+
             let tBuffer: GPUBuffer = null;
             while (this.mapAsyncReady.length) {
                 tBuffer = this.mapAsyncReady.shift();

--- a/src/gfx/graphics/webGpu/core/buffer/MatrixGPUBuffer.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/MatrixGPUBuffer.ts
@@ -32,6 +32,24 @@ export class MatrixGPUBuffer extends GPUBufferBase {
         let bytesLen = len;
         let device = webGPUContext.device;
         if (mapAsyncArray.length > 0) {
+            // iPadOS/iOS 26 Safari-specific handling; those devices will
+            // occasionally crash using the `getMappedRange` call.
+            // `device.queue.writeBuffer` is not universally available, so use
+            // manual buffer copying with `mapAsync` as a fallback.
+            if (typeof device.queue.writeBuffer !== 'undefined') {
+                if (len > mapAsyncArray.length) {
+                    throw new Error(`GPUBufferBase mapAsyncWrite length error. Tried to write ${len} float32s but array is only ${mapAsyncArray.length} float32s long.`);
+                }
+                webGPUContext.device.queue.writeBuffer(
+                    this.buffer,
+                    0,
+                    mapAsyncArray.buffer,
+                    mapAsyncArray.byteOffset,
+                    len * 4,
+                )
+                return;
+            }
+
             let tBuffer: GPUBuffer = null;
             while (this.mapAsyncReady.length) {
                 tBuffer = this.mapAsyncReady.shift();


### PR DESCRIPTION
by using GPUQueue.writeBuffer to copy buffers on iOS/iPadOS instead