### PR TITLE
Apple memory leak / usage improvements 

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
             overflow: overlay;
             border-right: 1px solid #fff;
             background: #000;
+            z-index: 1;
         }
 
         .menu>p {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-ios-memory-leak-workarounds",
+    "version": "0.8.5-dev.9-ios-memory-leak-workarounds-2",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "v0.8.5-dev.9-ios-memory-leak-workarounds",
+    "version": "0.8.5-dev.9-ios-memory-leak-workarounds",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "0.8.5-dev.9-use-GPUQueue.writeBuffer-to-fix-getMappedRange-error-on-iPadOS",
+    "version": "v0.8.5-dev.10-ios-memory-leak-workarounds",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orillusion/core",
-    "version": "v0.8.5-dev.10-ios-memory-leak-workarounds",
+    "version": "v0.8.5-dev.9-ios-memory-leak-workarounds",
     "author": "Orillusion",
     "description": "Orillusion WebGPU Engine",
     "type": "module",

--- a/samples/index.ts
+++ b/samples/index.ts
@@ -2,6 +2,7 @@
 {
     // find all demos in /sample
     const modules = import.meta.glob(['./*/*.ts', '!./*/_*.ts'])
+
     // create menu
     let title = '', list = `<svg onclick="document.body.classList.remove('show')" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="close"><path fill="currentColor" d="M764.288 214.592 512 466.88 259.712 214.592a31.936 31.936 0 0 0-45.12 45.12L466.752 512 214.528 764.224a31.936 31.936 0 1 0 45.12 45.184L512 557.184l252.288 252.288a31.936 31.936 0 0 0 45.12-45.12L557.12 512.064l252.288-252.352a31.936 31.936 0 1 0-45.12-45.184z"></path></svg>`
     for (const path in modules) {
@@ -15,21 +16,53 @@
         }
         list += `<a id="${path}">${_demo}</a>`
     }
+
     const menu = document.createElement('div')
     menu.className = 'menu'
     menu.innerHTML = list
     document.body.appendChild(menu)
 
-    // change sessionStorage.target on click, and reload iframe
+    // apply the same "fullscreen canvas" style that used to live in the iframe
+    {
+        const style = document.createElement('style')
+        style.textContent = `
+            html, body { margin: 0; padding: 0; overflow: hidden; }
+            canvas { touch-action: none; }
+        `
+        document.head.appendChild(style)
+    }
+
+    // helper: load and run a sample directly in this page (no iframe)
+    async function loadSample(target: string) {
+        const importer = modules[target]
+        if (!importer)
+            return
+
+        // remove previous canvases to avoid stacking multiple samples
+        document.querySelectorAll('canvas').forEach(c => c.remove())
+
+        const m = await importer()
+        for (const key in m as Record<string, unknown>) {
+            const Ctor = (m as Record<string, any>)[key]
+            if (typeof Ctor === 'function') {
+                const instance = new Ctor()
+                if (typeof instance.run === 'function') {
+                    instance.run()
+                }
+                break
+            }
+        }
+    }
+
+    // change sessionStorage.target on click, and load sample in-page
     menu.addEventListener('click', (e: Event) => {
         const button = e.target as HTMLElement
         if (!button.id)
             return
-        // remove prev iframe to clear memory
-        document.querySelector('iframe')?.remove()
+
         const target = button.id
         if (target && modules[target]) {
-            addIframe()
+            loadSample(target)
             document.querySelector('.active')?.classList.remove('active')
             button.classList.add('active')
             sessionStorage.top = menu.scrollTop
@@ -39,32 +72,15 @@
 
     // load target on refresh
     if (sessionStorage.target) {
-        const target = sessionStorage.target
-        const a = document.querySelector(`[id="${target}"]`)
+        const target = sessionStorage.target as string
+        const a = document.querySelector(`[id="${target}"]`) as HTMLElement | null
         if (a) {
-            addIframe()
+            loadSample(target)
             a.classList.add('active')
             menu.scrollTop = sessionStorage.top
         }
     } else {
-        document.querySelector('a')?.click()
-    }
-
-    // create an iframe inside page to load sample
-    function addIframe() {
-        const iframe = document.createElement('iframe') as HTMLIFrameElement
-        iframe.srcdoc = `
-        <style>html,body{margin:0;padding:0;overflow:hidden}canvas{touch-action:none}</style>
-        <script>
-            let target = sessionStorage.target
-            if(target)
-            import('${location.origin}/samples/'+target).then(m=>{
-                for(let i in m){
-                    new m[i]().run()
-                    break
-                }
-            })
-        </script>`
-        document.body.appendChild(iframe)
+        // fallback: click the first sample
+        (document.querySelector('a') as HTMLElement | null)?.click()
     }
 }

--- a/src/Engine3D.ts
+++ b/src/Engine3D.ts
@@ -496,11 +496,11 @@ export class Engine3D {
             if(!Engine3D.webKitWorkaround_IS_APPLE_DEVICE)
                 return;
             
-            const buffersToReset = [...GPUBufferBase.BuffersNeedingReset.values()];
+            const buffersToReset = [...GPUBufferBase.buffersNeedingReset.values()];
             if(buffersToReset.length) {
                 for (const buffer of buffersToReset) {
                     buffer["webKitWorkaround_Reset"]();
-                    GPUBufferBase.BuffersNeedingReset.delete(buffer);
+                    GPUBufferBase.buffersNeedingReset.delete(buffer);
                     // console.log(`Reset Buffers ${buffersToReset.length}, remaining: ${GPUBufferBase.BuffersNeedingReset.size}`);
                     return; // 1 per frame to avoid stutter
                 }

--- a/src/Engine3D.ts
+++ b/src/Engine3D.ts
@@ -24,6 +24,7 @@ import { FXAAPost } from './gfx/renderJob/post/FXAAPost';
 import { PostProcessingComponent } from './components/post/PostProcessingComponent';
 import { GBufferFrame } from './gfx/renderJob/frame/GBufferFrame';
 import { GPUTextureFormat } from './gfx/graphics/webGpu/WebGPUConst';
+import {GPUBufferBase} from "./gfx/graphics/webGpu/core/buffer/GPUBufferBase";
 
 /** 
  * Orillusion 3D Engine
@@ -468,12 +469,59 @@ export class Engine3D {
         this.resume()
     }
 
+
+    private static webKitWorkaround_isAppleDevice = (): boolean => {
+        if (typeof navigator === 'undefined') {
+            return false;
+        }
+
+        const ua = navigator.userAgent || '';
+        const platform = navigator.platform || '';
+
+        return (
+            /iPad|iPhone|iPod/.test(ua) ||
+            (/Mac/i.test(platform) && 'ontouchend' in document)
+        );
+    }
+
+    private static webKitWorkaround_IS_APPLE_DEVICE: boolean = undefined;
+    private static webKitWorkaround_IS_APPLE_DEVICE_check_error_logged = false;
+    
+    // Workaround for https://bugs.webkit.org/show_bug.cgi?id=303203
+    private static webKitWorkaround_resetBuffersIfNeeded() {
+        try {
+            if(Engine3D.webKitWorkaround_IS_APPLE_DEVICE == undefined)
+                Engine3D.webKitWorkaround_IS_APPLE_DEVICE = Engine3D.webKitWorkaround_isAppleDevice()
+            
+            if(!Engine3D.webKitWorkaround_IS_APPLE_DEVICE)
+                return;
+            
+            const buffersToReset = [...GPUBufferBase.BuffersNeedingReset.values()];
+            if(buffersToReset.length) {
+                for (const buffer of buffersToReset) {
+                    buffer["webKitWorkaround_Reset"]();
+                    GPUBufferBase.BuffersNeedingReset.delete(buffer);
+                    // console.log(`Reset Buffers ${buffersToReset.length}, remaining: ${GPUBufferBase.BuffersNeedingReset.size}`);
+                    return; // 1 per frame to avoid stutter
+                }
+            }
+        }
+        catch(e) {
+            if(!Engine3D.webKitWorkaround_IS_APPLE_DEVICE_check_error_logged) {
+                Engine3D.webKitWorkaround_IS_APPLE_DEVICE_check_error_logged = true;
+                console.error(`Error in Engine3D.webKitWorkaround_resetBuffersIfNeeded: ${e}`);
+            }
+        }
+    }
+
     public static async updateFrame(time: number) {
         Time.delta = time - Time.time;
         Time.time = time;
         Time.frame += 1;
         Interpolator.tick(Time.delta);
-
+        
+        this.webKitWorkaround_resetBuffersIfNeeded();
+        
         /* update all transform */
         let views = this.views;
         let i = 0;

--- a/src/Engine3D.ts
+++ b/src/Engine3D.ts
@@ -484,7 +484,7 @@ export class Engine3D {
         );
     }
 
-    private static webKitWorkaround_IS_APPLE_DEVICE: boolean = undefined;
+    public static webKitWorkaround_IS_APPLE_DEVICE: boolean = undefined;
     private static webKitWorkaround_IS_APPLE_DEVICE_check_error_logged = false;
     
     // Workaround for https://bugs.webkit.org/show_bug.cgi?id=303203

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -497,7 +497,7 @@ export class Res {
         }
     }
     
-    private static webKitWorkaround_recreateTexturesEvery = 30 * 1000;
+    private static webKitWorkaround_recreateTexturesEvery = 60 * 1000;
 
     /**
      * Initialize a common texture object. Provide a universal solid color texture object.

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -28,6 +28,8 @@ import { Ctor, Parser } from '../util/Global';
 import { ParserBase } from '../loader/parser/ParserBase';
 import { GeometryBase } from '../core/geometry/GeometryBase';
 import { LitMaterial } from '../materials/LitMaterial';
+import {RenderShaderPass} from "../gfx/graphics/webGpu/shader/RenderShaderPass";
+import {Engine3D} from "../Engine3D";
 
 /**
  * Resource management classes for textures, materials, models, and preset bodies.
@@ -434,7 +436,7 @@ export class Res {
      */
     public normalTexture: Uint8ArrayTexture;
     public maskTexture: Uint8ArrayTexture;
-    public whiteTexture: Uint8ArrayTexture;
+    public whiteTexture: Uint8ArrayTexture;    
     public blackTexture: Uint8ArrayTexture;
     public redTexture: Uint8ArrayTexture;
     public blueTexture: Uint8ArrayTexture;
@@ -494,6 +496,8 @@ export class Res {
             }
         }
     }
+    
+    private static webKitWorkaround_recreateTexturesEvery = 1000
 
     /**
      * Initialize a common texture object. Provide a universal solid color texture object.
@@ -508,6 +512,27 @@ export class Res {
         this.greenTexture = this.createTexture(32, 32, 0, 255, 0, 255, 'default-greenTexture');
         this.yellowTexture = this.createTexture(32, 32, 0, 255, 255, 255.0, 'default-yellowTexture');
         this.grayTexture = this.createTexture(32, 32, 128, 128, 128, 255.0, 'default-grayTexture');
+        
+        if(Engine3D.webKitWorkaround_IS_APPLE_DEVICE) {
+            setTimeout(() => {
+                const oldWhiteTexture = this.whiteTexture;
+                this.whiteTexture = this.createTexture(32, 32, 255, 255, 255, 255, 'default-whiteTexture-recreated');
+                
+                for (const pass of RenderShaderPass.AllPasses) {
+                    for (const textureKey in pass.textures) {
+                        const texture = pass.getTexture(textureKey);
+                        if(texture && texture.name) {
+                            if(texture.name.indexOf('default-whiteTexture') !== -1) {
+                                pass.setTexture(textureKey, this.whiteTexture);
+                            }
+                        }
+                    }
+                }
+
+                this.defaultGUITexture.texture = this.whiteTexture;
+                
+            }, Res.webKitWorkaround_recreateTexturesEvery);
+        }
 
         let brdf = new BRDFLUTGenerate();
         let brdf_texture = brdf.generateBRDFLUTTexture();

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -535,6 +535,32 @@ export class Res {
                     oldWhiteTexture.destroy(true);
                 }, 100);
             }, Res.webKitWorkaround_recreateTexturesEvery);
+
+            const reloadFonts = async () => {
+                const fontUrl = "/bmfont/roboto_0.png"; // hardcoded webkit issue workaround
+                const fontName = fontUrl.split("/").reverse()[0].split(".")[0];
+                const oldFontTexture = this._texturePool.get(fontUrl);
+                if(oldFontTexture) {
+                    let newFontTexture = new BitmapTexture2D();
+                    newFontTexture.flipY = oldFontTexture.flipY;
+                    await newFontTexture.load(fontUrl, null, true);
+                    this._texturePool.set(fontUrl, newFontTexture);
+                    
+                    const guiSprites = GUISprite.Instances;
+                    for(let sprite of guiSprites) {
+                        if(sprite.guiTexture.texture.name.indexOf(fontName) !== -1) {
+                            sprite.guiTexture.texture = newFontTexture;
+                        }
+                    }
+                    setTimeout(() => {
+                        oldFontTexture.destroy(true);
+                    }, 100);
+                }
+
+                setTimeout(() => reloadFonts(), Res.webKitWorkaround_recreateTexturesEvery);
+            }
+            
+            setTimeout(() => reloadFonts(), Res.webKitWorkaround_recreateTexturesEvery);
         }
 
         let brdf = new BRDFLUTGenerate();

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -515,6 +515,9 @@ export class Res {
         
         if(Engine3D.webKitWorkaround_IS_APPLE_DEVICE) {
             setInterval(() => {
+                // white texture is used as baseMap for lots of default shaders / materials, that means it's used really heavily for
+                // GPU calls which makes it accumulate a lot of memory-leak due to WebKit bug. Recreating the texture periodically forces
+                // webkit to drop encoder-ids tracking set
                 const oldWhiteTexture = this.whiteTexture;
                 this.whiteTexture = this.createTexture(32, 32, 255, 255, 255, 255, 'default-whiteTexture-recreated');
                 
@@ -537,6 +540,8 @@ export class Res {
             }, Res.webKitWorkaround_recreateTexturesEvery);
 
             const reloadFonts = async () => {
+                // Similar as with white-texture, roboto is our main font used in all game-UIs, it's used heavily
+                // reloading it forces WebKit to drop encoder-ids tracking set same as it does for white-texture
                 const fontUrl = "/bmfont/roboto_0.png"; // hardcoded webkit issue workaround
                 const fontName = fontUrl.split("/").reverse()[0].split(".")[0];
                 const oldFontTexture = this._texturePool.get(fontUrl);

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -531,6 +531,10 @@ export class Res {
 
                 this.defaultGUITexture.texture = this.whiteTexture;
                 
+                oldWhiteTexture.destroy(true);
+                setTimeout(() => {
+                    oldWhiteTexture.destroy(true);
+                }, 100);
             }, Res.webKitWorkaround_recreateTexturesEvery);
         }
 

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -497,7 +497,7 @@ export class Res {
         }
     }
     
-    private static webKitWorkaround_recreateTexturesEvery = 1000
+    private static webKitWorkaround_recreateTexturesEvery = 30 * 1000;
 
     /**
      * Initialize a common texture object. Provide a universal solid color texture object.
@@ -514,7 +514,7 @@ export class Res {
         this.grayTexture = this.createTexture(32, 32, 128, 128, 128, 255.0, 'default-grayTexture');
         
         if(Engine3D.webKitWorkaround_IS_APPLE_DEVICE) {
-            setTimeout(() => {
+            setInterval(() => {
                 const oldWhiteTexture = this.whiteTexture;
                 this.whiteTexture = this.createTexture(32, 32, 255, 255, 255, 255, 'default-whiteTexture-recreated');
                 

--- a/src/assets/Res.ts
+++ b/src/assets/Res.ts
@@ -531,7 +531,6 @@ export class Res {
 
                 this.defaultGUITexture.texture = this.whiteTexture;
                 
-                oldWhiteTexture.destroy(true);
                 setTimeout(() => {
                     oldWhiteTexture.destroy(true);
                 }, 100);

--- a/src/components/gui/core/GUISprite.ts
+++ b/src/components/gui/core/GUISprite.ts
@@ -27,7 +27,10 @@ export class GUISprite {
     public xoffset: number = 0;
     public yoffset: number = 0;
 
+    public static Instances: Array<GUISprite> = [];
+
     constructor(texture?: GUITexture) {
+        GUISprite.Instances.push(this);
         this.guiTexture = texture || Engine3D.res.defaultGUITexture;
     }
 }

--- a/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
@@ -18,8 +18,8 @@ import { FloatArray } from "../../../../../components/matrix/WasmMatrix";
  * @group GFX
  */
 export class GPUBufferBase {
-    static BuffersNeedingReset: Set<GPUBufferBase> = new Set<GPUBufferBase>();
-    static ResetEveryNEncoderUsageCount = 10000;
+    static buffersNeedingReset: Set<GPUBufferBase> = new Set<GPUBufferBase>();
+    static resetEveryNEncoderUsageCount = 10000;
     
     public bufferType: GPUBufferType;
     public buffer: GPUBuffer;
@@ -50,8 +50,8 @@ export class GPUBufferBase {
             return;
         
         this._encoderUsageCount++;
-        if(this._encoderUsageCount % GPUBufferBase.ResetEveryNEncoderUsageCount == 0) {
-            GPUBufferBase.BuffersNeedingReset.add(this);
+        if(this._encoderUsageCount % GPUBufferBase.resetEveryNEncoderUsageCount == 0) {
+            GPUBufferBase.buffersNeedingReset.add(this);
         }
     }
 

--- a/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/GPUBufferBase.ts
@@ -18,6 +18,9 @@ import { FloatArray } from "../../../../../components/matrix/WasmMatrix";
  * @group GFX
  */
 export class GPUBufferBase {
+    static BuffersNeedingReset: Set<GPUBufferBase> = new Set<GPUBufferBase>();
+    static ResetEveryNEncoderUsageCount = 10000;
+    
     public bufferType: GPUBufferType;
     public buffer: GPUBuffer;
     public memory: MemoryDO;
@@ -29,9 +32,9 @@ export class GPUBufferBase {
     public visibility: number = GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE;
     protected mapAsyncBuffersOutstanding = 0;
     protected mapAsyncReady: GPUBuffer[];
-    private _readBuffer: GPUBuffer;
+    protected _readBuffer: GPUBuffer;
     private _dataView: Float32Array;
-
+    private _encoderUsageCount = 0;
     constructor() {
         this.mapAsyncReady = [];
         // this.memory = new MemoryDO();
@@ -40,6 +43,16 @@ export class GPUBufferBase {
     }
 
     public debug() {
+    }
+    
+    public webKitWorkaround_trackUsageAndMarkForResetIfNeeded() {
+        if(this['webKitWorkaround_Reset'] === undefined) // check if inheriting class is supporting
+            return;
+        
+        this._encoderUsageCount++;
+        if(this._encoderUsageCount % GPUBufferBase.ResetEveryNEncoderUsageCount == 0) {
+            GPUBufferBase.BuffersNeedingReset.add(this);
+        }
     }
 
     public reset(clean: boolean = false, size: number = 0, data?: Float32Array) {

--- a/src/gfx/graphics/webGpu/core/buffer/IndicesGPUBuffer.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/IndicesGPUBuffer.ts
@@ -19,6 +19,29 @@ export class IndicesGPUBuffer extends GPUBufferBase {
         this.createIndicesBuffer(GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT, data);
     }
 
+    public webKitWorkaround_Reset() {
+        let device = webGPUContext.device;
+        const usage = this.buffer.usage;
+        const size = this.buffer.size;
+        
+        if (this.buffer) {
+            this.buffer.destroy();
+            
+        }
+        if (this._readBuffer) {
+            this._readBuffer.destroy();
+        }
+        
+        this.buffer = device.createBuffer({
+            label: "IndicesGPUBuffer",
+            size: size,
+            usage: usage,
+            mappedAtCreation: false,
+        });
+
+        this.apply();
+    }
+
     protected createIndicesBuffer(usage: GPUBufferUsageFlags, data?: ArrayBufferData) {
         let device = webGPUContext.device;
         this.byteSize = data.length * 4;

--- a/src/gfx/graphics/webGpu/core/buffer/VertexGPUBuffer.ts
+++ b/src/gfx/graphics/webGpu/core/buffer/VertexGPUBuffer.ts
@@ -17,6 +17,25 @@ export class VertexGPUBuffer extends GPUBufferBase {
         this.bufferType = GPUBufferType.VertexGPUBuffer;
         this.createVertexBuffer(GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX, size);
     }
+    
+    public webKitWorkaround_Reset() {
+        let device = webGPUContext.device;
+        const usage = this.buffer.usage;
+        if (this.buffer) {
+            this.buffer.destroy();
+        }
+        if (this._readBuffer) {
+            this._readBuffer.destroy();
+        }
+        
+        this.buffer = device.createBuffer({
+            label: "VertexGPUBuffer",
+            size: this.byteSize,
+            usage: usage,
+            mappedAtCreation: false,
+        });
+        this.apply();
+    }
 
     protected createVertexBuffer(usage: GPUBufferUsageFlags, size: number) {
         let device = webGPUContext.device;

--- a/src/gfx/graphics/webGpu/shader/RenderShaderPass.ts
+++ b/src/gfx/graphics/webGpu/shader/RenderShaderPass.ts
@@ -82,9 +82,12 @@ export class RenderShaderPass extends ShaderPassBase {
     protected _textureChange: boolean = false;
     protected _groupsShaderReflectionVarInfos: ShaderReflectionVarInfo[][];
     outBufferMask: Vector4;
+    
+    public static AllPasses: Array<RenderShaderPass> = [];
 
     constructor(vs: string, fs: string) {
         super();
+        RenderShaderPass.AllPasses.push(this);
 
         this.vsName = vs.toLowerCase();
         this.fsName = fs.toLowerCase();

--- a/src/gfx/renderJob/GPUContext.ts
+++ b/src/gfx/renderJob/GPUContext.ts
@@ -71,13 +71,16 @@ export class GPUContext {
         if (this.lastGeometry != geometry) {
             this.lastGeometry = geometry;
 
-            if (geometry.indicesBuffer)
+            if (geometry.indicesBuffer) {
+                geometry.indicesBuffer.indicesGPUBuffer.webKitWorkaround_trackUsageAndMarkForResetIfNeeded();
                 encoder.setIndexBuffer(geometry.indicesBuffer.indicesGPUBuffer.buffer, geometry.indicesBuffer.indicesFormat);
+            }
 
             let vertexBuffer = geometry.vertexBuffer.vertexGPUBuffer;
             let vertexBufferLayouts = geometry.vertexBuffer.vertexBufferLayouts;
             for (let i = 0; i < vertexBufferLayouts.length; i++) {
                 const vbLayout = vertexBufferLayouts[i];
+                vertexBuffer.webKitWorkaround_trackUsageAndMarkForResetIfNeeded();
                 encoder.setVertexBuffer(i, vertexBuffer.buffer, vbLayout.offset, vbLayout.size);
             }
         }

--- a/src/gfx/renderJob/jobs/RendererJob.ts
+++ b/src/gfx/renderJob/jobs/RendererJob.ts
@@ -211,25 +211,29 @@ export class RendererJob {
 
         this.occlusionSystem.update(view.camera, view.scene);
         this.clusterLightingRender.render(view, this.occlusionSystem);
+        
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // if (this.shadowMapPassRenderer) {
+        //     ShadowLightsCollect.update(view);
+        //     this.shadowMapPassRenderer.render(view, this.occlusionSystem);
+        // }
 
-        if (this.shadowMapPassRenderer) {
-            ShadowLightsCollect.update(view);
-            this.shadowMapPassRenderer.render(view, this.occlusionSystem);
-        }
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // if (this.pointLightShadowRenderer) {
+        //     this.pointLightShadowRenderer.render(view, this.occlusionSystem);
+        // }
 
-        if (this.pointLightShadowRenderer) {
-            this.pointLightShadowRenderer.render(view, this.occlusionSystem);
-        }
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // if (this.depthPassRenderer) {
+        //     this.depthPassRenderer.compute(view, this.occlusionSystem);
+        //     this.depthPassRenderer.render(view, this.occlusionSystem);
+        // }
 
-        if (this.depthPassRenderer) {
-            this.depthPassRenderer.compute(view, this.occlusionSystem);
-            this.depthPassRenderer.render(view, this.occlusionSystem);
-        }
-
-        if (Engine3D.setting.gi.enable && this.ddgiProbeRenderer) {
-            this.ddgiProbeRenderer.compute(view, this.occlusionSystem);
-            this.ddgiProbeRenderer.render(view, this.occlusionSystem);
-        }
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // if (Engine3D.setting.gi.enable && this.ddgiProbeRenderer) {
+        //     this.ddgiProbeRenderer.compute(view, this.occlusionSystem);
+        //     this.ddgiProbeRenderer.render(view, this.occlusionSystem);
+        // }
 
 
         let passList = this.rendererMap.getAllPassRenderer();

--- a/src/gfx/renderJob/passRenderer/ddgi/DDGIProbeRenderer.ts
+++ b/src/gfx/renderJob/passRenderer/ddgi/DDGIProbeRenderer.ts
@@ -62,28 +62,29 @@ export class DDGIProbeRenderer extends RendererBase {
     constructor(volume: DDGIIrradianceVolume) {
         super();
 
-        this.passType = PassType.GI;
-
-        this.volume = volume;
-        let giSetting = volume.setting;
-
-        this.cubeCamera = new CubeCamera(0.01, 5000);
-
-        this.sizeW = giSetting.probeSourceTextureSize;
-        this.sizeH = giSetting.probeSourceTextureSize;
-
-        this.probeNext = giSetting.probeSourceTextureSize / giSetting.probeSize;
-
-        this.initIrradianceMap(volume);
-
-        this.probeRenderResult = new ProbeRenderResult();
-
-        let probeGBufferFrame = new ProbeGBufferFrame(this.sizeW, this.sizeH, false);
-        this.positionMap = probeGBufferFrame.renderTargets[0];
-        this.normalMap = probeGBufferFrame.renderTargets[1];
-        this.colorMap = probeGBufferFrame.renderTargets[2];
-
-        this.setRenderStates(probeGBufferFrame);
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // this.passType = PassType.GI;
+        //
+        // this.volume = volume;
+        // let giSetting = volume.setting;
+        //
+        // this.cubeCamera = new CubeCamera(0.01, 5000);
+        //
+        // this.sizeW = giSetting.probeSourceTextureSize;
+        // this.sizeH = giSetting.probeSourceTextureSize;
+        //
+        // this.probeNext = giSetting.probeSourceTextureSize / giSetting.probeSize;
+        //
+        // this.initIrradianceMap(volume);
+        //
+        // this.probeRenderResult = new ProbeRenderResult();
+        //
+        // let probeGBufferFrame = new ProbeGBufferFrame(this.sizeW, this.sizeH, false);
+        // this.positionMap = probeGBufferFrame.renderTargets[0];
+        // this.normalMap = probeGBufferFrame.renderTargets[1];
+        // this.colorMap = probeGBufferFrame.renderTargets[2];
+        //
+        // this.setRenderStates(probeGBufferFrame);
     }
 
     /**

--- a/src/gfx/renderJob/passRenderer/preDepth/PreDepthPassRenderer.ts
+++ b/src/gfx/renderJob/passRenderer/preDepth/PreDepthPassRenderer.ts
@@ -28,23 +28,25 @@ export class PreDepthPassRenderer extends RendererBase {
     zCullingCompute: ZCullingCompute;
     constructor() {
         super();
-        this.passType = PassType.DEPTH;
-
-        let size = webGPUContext.presentationSize;
-        let scale = 1;
-        this.zBufferTexture = RTResourceMap.createRTTexture(RTResourceConfig.zBufferTexture_NAME, Math.floor(size[0] * scale), Math.floor(size[1] * scale), GPUTextureFormat.rgba16float, false);
-        let rtDec = new RTDescriptor()
-        rtDec.clearValue = [0, 0, 0, 0];
-        rtDec.loadOp = `clear`;
-        let rtFrame = new RTFrame([
-        ], [
-            // new RTDescriptor()
-        ],
-            RTResourceMap.createRTTexture(RTResourceConfig.zPreDepthTexture_NAME, Math.floor(size[0]), Math.floor(size[1]), GPUTextureFormat.depth32float, false),
-            null,
-            false
-        );
-        this.setRenderStates(rtFrame);
+        
+        //TODO: 5189 - ios workaround to reduce memory use/leak. For now we're not using those orillusion features
+        // this.passType = PassType.DEPTH;
+        //
+        // let size = webGPUContext.presentationSize;
+        // let scale = 1;
+        // this.zBufferTexture = RTResourceMap.createRTTexture(RTResourceConfig.zBufferTexture_NAME, Math.floor(size[0] * scale), Math.floor(size[1] * scale), GPUTextureFormat.rgba16float, false);
+        // let rtDec = new RTDescriptor()
+        // rtDec.clearValue = [0, 0, 0, 0];
+        // rtDec.loadOp = `clear`;
+        // let rtFrame = new RTFrame([
+        // ], [
+        //     // new RTDescriptor()
+        // ],
+        //     RTResourceMap.createRTTexture(RTResourceConfig.zPreDepthTexture_NAME, Math.floor(size[0]), Math.floor(size[1]), GPUTextureFormat.depth32float, false),
+        //     null,
+        //     false
+        // );
+        // this.setRenderStates(rtFrame);
     }
 
     render(view: View3D, occlusionSystem: OcclusionSystem) {

--- a/src/gfx/renderJob/passRenderer/shadow/PointLightShadowRenderer.ts
+++ b/src/gfx/renderJob/passRenderer/shadow/PointLightShadowRenderer.ts
@@ -48,7 +48,7 @@ export class PointLightShadowRenderer extends RendererBase {
         super();
         this.passType = PassType.POINT_SHADOW;
 
-        // this.shadowSize = Engine3D.setting.shadow.pointShadowSize;
+        this.shadowSize = Engine3D.setting.shadow.pointShadowSize;
         this._shadowCameraDic = new Map<ILight, CubeShadowMapInfo>();
         this.cubeArrayTexture = new DepthCubeArrayTexture(this.shadowSize, this.shadowSize, 8);
         this.colorTexture = new VirtualTexture(this.shadowSize, this.shadowSize, GPUTextureFormat.bgra8unorm, false);

--- a/src/textures/BitmapTexture2D.ts
+++ b/src/textures/BitmapTexture2D.ts
@@ -11,6 +11,7 @@ import { Texture } from '../gfx/graphics/webGpu/core/texture/Texture';
 export class BitmapTexture2D extends Texture {
     private _source: HTMLCanvasElement | ImageBitmap | OffscreenCanvas | HTMLImageElement;
     public premultiplyAlpha: PremultiplyAlpha = 'none';
+    private static _bitmapCache = new Map<string, ImageBitmap>();
 
     /**
      * @constructor
@@ -59,45 +60,66 @@ export class BitmapTexture2D extends Texture {
      * @param url web url
      * @param loaderFunctions callback function when load complete
      */
-    public async load(url: string, loaderFunctions?: LoaderFunctions) {
+    public async load(url: string, loaderFunctions?: LoaderFunctions, allowCache: boolean = false) {
         this.name = StringUtil.getURLName(url);
-        if (url.indexOf(';base64') != -1) {
-            const img = document.createElement('img');
-            let start = url.indexOf('data:image');
-            let uri = url.substring(start, url.length);
+        const cacheKey = `${url}|flipY=${this.flipY ? 1 : 0}`;
+        
+        if(allowCache) {
+            const cached = BitmapTexture2D._bitmapCache.get(cacheKey);
+            if (cached) {
+                console.log(`BitmapTexture2D load from cache ${url}`);
+                this.format = GPUTextureFormat.rgba8unorm;
+                this.generate(cached);
+                return true;
+            }
+        }
+
+        console.log(`BitmapTexture2D load ${url}`);
+        let imageBitmap: ImageBitmap;
+
+        if (url.indexOf(";base64") !== -1) {
+            const img = document.createElement("img");
+            const start = url.indexOf("data:image");
+            const uri = start >= 0 ? url.substring(start) : url;
+
             img.src = uri;
             await img.decode();
+
             img.width = Math.max(img.width, 32);
             img.height = Math.max(img.height, 32);
-            const imageBitmap = await createImageBitmap(img, {
+
+            imageBitmap = await createImageBitmap(img, {
                 resizeWidth: img.width,
                 resizeHeight: img.height,
                 imageOrientation: this.flipY ? "flipY" : "from-image",
-                premultiplyAlpha: 'none'
+                premultiplyAlpha: "none",
             });
-            this.format = GPUTextureFormat.rgba8unorm;
-            this.generate(imageBitmap);
         } else {
-            return new Promise((succ, fial) => {
-                fetch(url, {
-                    headers: Object.assign({
-                        'Accept': 'image/avif,image/webp,*/*'
-                    }, loaderFunctions?.headers)
-                }).then((r) => {
-                    // const img = await r.blob();
-                    // await this.loadFromBlob(img);
-                    LoaderBase.read(url, r, loaderFunctions).then((chunks) => {
-                        let img = new Blob([chunks], { type: 'image/jpeg' });
-                        chunks = null;
-                        this.loadFromBlob(img).then(() => {
-                            succ(true);
-                        });
-                    });
+            const r = await fetch(url, {
+                headers: Object.assign(
+                    { Accept: "image/avif,image/webp,*/*" },
+                    loaderFunctions?.headers
+                ),
+            });
 
-                })
-            })
+            const chunks = await LoaderBase.read(url, r, loaderFunctions);
 
+            // Prefer real content-type if available
+            const contentType = r.headers.get("content-type") ?? "application/octet-stream";
+            const blob = new Blob([chunks], { type: contentType });
+
+            imageBitmap = await createImageBitmap(blob, {
+                imageOrientation: this.flipY ? "flipY" : "from-image",
+                premultiplyAlpha: "none",
+            });
         }
+
+        if(allowCache) {
+            BitmapTexture2D._bitmapCache.set(cacheKey, imageBitmap);
+        }
+
+        this.format = GPUTextureFormat.rgba8unorm;
+        this.generate(imageBitmap);
         return true;
     }
 


### PR DESCRIPTION

Apple has a confirmed memory leak in 26.1 version. This is causing our apps to crash (in our case mainly ipad as the ram there is constrained)

https://bugs.webkit.org/show_bug.cgi?id=303203

This is a temporary workaround that should remain in place till fix is released and we've given user some chance to update devices.

It'll
- disable some orillusion features that assign somewhat large textures - this will help with general memory consumption on all devices and can remain in place even after apple fix release (although if we'd like to use those features, eg shadows we'll need to re-enable)
- reset GPU buffers every 10000 usages, this destroys GPU resource and Webkit will remove trackedEncoders array that's source of leak
- recreates 'white' texture that's used in a lot of base shaders and accumulates encoders
- recreates roboto font that's specific to LV - this also releases accumulated encoders (also adjusted load method so font can be loaded from cache instead of fetching)
- font load cache is only present on BitmapTexture2D class level, so initial load will still fetch fonts, + additional fetch to save directly via cache, then it'll continue coming from cache. This is as I wanted to isolate changes that we have to do and adjusting font loading code would need multiple edits / api changes

*also minor change to how samples are run so https://github.com/brendan-duncan/webgpu_inspector can capture them